### PR TITLE
Added default avatar for recent activity feed

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -254,7 +254,11 @@
                                     <div class="opaque-container">
                                         <div class="review-metadata-box">
                                             <div class="avatar-container">
-                                                <img class="avatar-img" src="{{ recent.user.user_profile.photo }}" alt="" height="50" width="50" />
+                                                {% if recent.user.user_profile.photo %}
+                                                    <img class="avatar-img" src="{{ recent.user.user_profile.photo }}" alt="" height="50" width="50" />
+                                                {% else %}
+                                                    <img class="avatar-img" src="https://s3-media3.fl.yelpcdn.com/photo/O8CmQtEeOUvMTFk0iMn5sw/o.jpg" alt="" height="50" width="50" />
+                                                {% endif %}
                                             </div>
                                             <div class="user-timestamp">
                                                 <p class="user-name" style="float: left;">{{ recent.user }}</p>


### PR DESCRIPTION
The recent activity feed feature for user avatar did not have a default image for user's that don't have their profile pictures set. This fix adds the default image if the user doesn't have a profile picture.