### PR TITLE
Alter the browse UI so that user can see the map even when they scroll down the restaurants

### DIFF
--- a/restaurant/templates/browse.html
+++ b/restaurant/templates/browse.html
@@ -468,14 +468,15 @@ $(document).ready(function(){
                     <div class="column-box">
                         <div class="hundred-width" style="width:100%;">
                             <center>
-                                <div id="map"></div>
-                            </center>
+                                <div id="map"></div>  
+                            </center>                
                         </div>
                     </div>
-                    <div class="column-box">
+                    <div class="column-box" id="RestaruantsDiv" style="overflow-y:scroll;overflow-x:hidden;">
                         <div id="res_list_group" class="row"></div>
                     </div>
                 </div>
+                <br></br>
                 <center>
                     <div class="text-center">
                         <button type="button" class="btn btn-dark mb-2" onclick="load_more()" id="load_button">Load More</button>
@@ -484,9 +485,9 @@ $(document).ready(function(){
                         </a>
                     </div>
                 </center>
-            </div>
-            
         </div>
+            
+    </div>
 
         <script type="text/javascript">
           function clearRestaurant() {
@@ -775,6 +776,123 @@ $(document).ready(function(){
             });
         </script>
     </div>
+    <style>
+        
+        #map {
+            height: 550px;
+            width: 550px;
+        }
+        #RestaruantsDiv{
+            height: 550px;
+        }
+        @media screen and (max-width: 1225px) {
+            #map {
+                height: 500px;
+                width: 500px;
+            }
+            #RestaruantsDiv{
+                height: 500px;
+            }
+        }
+
+        @media screen and (max-width: 1175px) {
+            #map {
+                height: 450px;
+                width: 450px;
+            }
+            #RestaruantsDiv{
+                height: 450px;
+            }
+        }
+
+        @media screen and (max-width: 1090px) {
+            #map {
+                height: 400px;
+                width: 400px;
+            }
+            #RestaruantsDiv{
+                height: 400px;
+            }
+        }
+
+        @media screen and (max-width: 990px) {
+            .column-box {
+                width: 100%;
+            }
+
+            #map {
+                width: 800px;
+                height: 500px;
+            }
+            #RestaruantsDiv{
+                height: 500px;
+            }
+        }
+
+        @media screen and (max-width: 840px) {
+            .column-box {
+                width: 100%;
+            }
+
+            #map {
+                width: 750px;
+                height: 450px;
+            }
+            #RestaruantsDiv{
+                height: 450px;
+            }
+        }
+
+        @media screen and (max-width: 775px){
+            #map {
+                height: 500px;
+                width: 500px;
+            }
+            #RestaruantsDiv{
+                height: 500px;
+            }
+        }
+
+        @media screen and (max-width: 600px){
+            #map {
+                height: 400px;
+                width: 400px;
+            }
+            #RestaruantsDiv{
+                height: 400px;
+            }
+        }
+
+        @media screen and (max-width: 500px){
+            #map {
+                height: 335px;
+                width: 335px;
+            }
+            #RestaruantsDiv{
+                height: 335px;
+            }
+        }
+            #RestaruantsDiv{
+                scrollbar-width: thin;
+                scrollbar-color: #596ff8 white;
+              }
+              
+              /* Works on Chrome, Edge, and Safari */
+              #RestaruantsDiv::-webkit-scrollbar {
+                width: 12px;
+              }
+              
+              #RestaruantsDiv::-webkit-scrollbar-track {
+                background: white;
+              }
+              
+              #RestaruantsDiv::-webkit-scrollbar-thumb {
+                background-color:#596ff8;
+                border-radius: 20px;
+                border: 3px solid white;
+              }
+
+    </style>
     <script>
         window.onload = function () {
           var loaded = 0;

--- a/restaurant/templates/browse.html
+++ b/restaurant/templates/browse.html
@@ -468,11 +468,11 @@ $(document).ready(function(){
                     <div class="column-box">
                         <div class="hundred-width" style="width:100%;">
                             <center>
-                                <div id="map"></div>  
-                            </center>                
+                                <div id="map"></div>      
+                            </center>    
                         </div>
                     </div>
-                    <div class="column-box" id="RestaruantsDiv" style="overflow-y:scroll;overflow-x:hidden;">
+                    <div class="column-box" id="RestaruantsDiv">
                         <div id="res_list_group" class="row"></div>
                     </div>
                 </div>
@@ -776,123 +776,7 @@ $(document).ready(function(){
             });
         </script>
     </div>
-    <style>
-        
-        #map {
-            height: 550px;
-            width: 550px;
-        }
-        #RestaruantsDiv{
-            height: 550px;
-        }
-        @media screen and (max-width: 1225px) {
-            #map {
-                height: 500px;
-                width: 500px;
-            }
-            #RestaruantsDiv{
-                height: 500px;
-            }
-        }
 
-        @media screen and (max-width: 1175px) {
-            #map {
-                height: 450px;
-                width: 450px;
-            }
-            #RestaruantsDiv{
-                height: 450px;
-            }
-        }
-
-        @media screen and (max-width: 1090px) {
-            #map {
-                height: 400px;
-                width: 400px;
-            }
-            #RestaruantsDiv{
-                height: 400px;
-            }
-        }
-
-        @media screen and (max-width: 990px) {
-            .column-box {
-                width: 100%;
-            }
-
-            #map {
-                width: 800px;
-                height: 500px;
-            }
-            #RestaruantsDiv{
-                height: 500px;
-            }
-        }
-
-        @media screen and (max-width: 840px) {
-            .column-box {
-                width: 100%;
-            }
-
-            #map {
-                width: 750px;
-                height: 450px;
-            }
-            #RestaruantsDiv{
-                height: 450px;
-            }
-        }
-
-        @media screen and (max-width: 775px){
-            #map {
-                height: 500px;
-                width: 500px;
-            }
-            #RestaruantsDiv{
-                height: 500px;
-            }
-        }
-
-        @media screen and (max-width: 600px){
-            #map {
-                height: 400px;
-                width: 400px;
-            }
-            #RestaruantsDiv{
-                height: 400px;
-            }
-        }
-
-        @media screen and (max-width: 500px){
-            #map {
-                height: 335px;
-                width: 335px;
-            }
-            #RestaruantsDiv{
-                height: 335px;
-            }
-        }
-            #RestaruantsDiv{
-                scrollbar-width: thin;
-                scrollbar-color: #596ff8 white;
-              }
-              
-              /* Works on Chrome, Edge, and Safari */
-              #RestaruantsDiv::-webkit-scrollbar {
-                width: 12px;
-              }
-              
-              #RestaruantsDiv::-webkit-scrollbar-track {
-                background: white;
-              }
-              
-              #RestaruantsDiv::-webkit-scrollbar-thumb {
-                background-color:#596ff8;
-                border-radius: 20px;
-                border: 3px solid white;
-              }
-
-    </style>
     <script>
         window.onload = function () {
           var loaded = 0;

--- a/static/css/browse.css
+++ b/static/css/browse.css
@@ -23,11 +23,16 @@
     height: 550px;
     width: 550px;
 }
-
+#RestaruantsDiv{
+    height: 550px;
+}
 @media screen and (max-width: 1225px) {
     #map {
         height: 500px;
         width: 500px;
+    }
+    #RestaruantsDiv{
+        height: 500px;
     }
 }
 
@@ -36,12 +41,18 @@
         height: 450px;
         width: 450px;
     }
+    #RestaruantsDiv{
+        height: 450px;
+    }
 }
 
 @media screen and (max-width: 1090px) {
     #map {
         height: 400px;
         width: 400px;
+    }
+    #RestaruantsDiv{
+        height: 400px;
     }
 }
 
@@ -52,6 +63,9 @@
 
     #map {
         width: 800px;
+        height: 500px;
+    }
+    #RestaruantsDiv{
         height: 500px;
     }
 }
@@ -65,12 +79,18 @@
         width: 750px;
         height: 450px;
     }
+    #RestaruantsDiv{
+        height: 450px;
+    }
 }
 
 @media screen and (max-width: 775px){
     #map {
         height: 500px;
         width: 500px;
+    }
+    #RestaruantsDiv{
+        height: 500px;
     }
 }
 
@@ -79,11 +99,17 @@
         height: 400px;
         width: 400px;
     }
+    #RestaruantsDiv{
+        height: 400px;
+    }
 }
 
 @media screen and (max-width: 500px){
     #map {
         height: 335px;
         width: 335px;
+    }
+    #RestaruantsDiv{
+        height: 335px;
     }
 }

--- a/static/css/browse.css
+++ b/static/css/browse.css
@@ -25,7 +25,31 @@
 }
 #RestaruantsDiv{
     height: 550px;
+    overflow-y:scroll;
+    overflow-x:hidden;
 }
+
+#RestaruantsDiv{
+    scrollbar-width: thin;
+    scrollbar-color: #596ff8 white;
+}
+  
+/* Works on Chrome, Edge, and Safari */
+#RestaruantsDiv::-webkit-scrollbar {
+    width: 12px;
+}
+  
+#RestaruantsDiv::-webkit-scrollbar-track {
+    background: white;
+}
+  
+#RestaruantsDiv::-webkit-scrollbar-thumb {
+    background-color:#596ff8;
+    border-radius: 20px;
+    border: 3px solid white;
+}
+
+
 @media screen and (max-width: 1225px) {
     #map {
         height: 500px;


### PR DESCRIPTION
This PR aims to simplify the browse restaurants page by adding a scroll bar to view the restaurants, which makes the map always visible even when the user scrolls down the restaurants.
Changes I made include:
-adding a scroll bar to the div that displays the restaurants  and adding styling to the scroll bar
-giving a certain height to the div that displays restaurants (height same as the map's height)
