### PR TITLE
DineLine consistent across all webpages 

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,8 +3,8 @@
     <div class="container py-6 py-lg-7 text-white overlay-content text-center">
         <div class="row">
             <div class="col-xl-10 mx-auto">
-                <h1 class="display-3 font-weight-bold text-shadow">Dine Line</h1>
-                <p class="text-lg text-shadow">Uncover safe places to eat and drink.</p>
+                <h1 class="display-3 font-weight-bold text-shadow">DineLine</h1>
+                <p class="text-lg text-shadow">Uncover safe and accessible places to eat and drink.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Title
Make Dine Line into DineLine across all webpages

## Description 
There are instances on the website where it says Dine Line whereas it should say DineLine (without a space). This was only present on the homepage. Also changed "Uncover safe places to eat and drink" to "Uncover safe and accessible places to eat and drink".

## Types of changes
*Put an `x` in the boxes that apply*
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/gcivil-nyu-org/spring2021-cs-gy-9223-class/blob/main/CONTRIBUTING.md) guidelines of this project
- [x] My code follows the code style of this project
- [x] New unit tests have been added to prove my fix is effective or my feature works
- [x] All new and existing unit tests have passed locally
- [x] Mention new environment variables if any have been added to env file
- [x] Any new required python modules are added to the requirements.txt
- [x] All checks (continuous integration build) should pass and test coverage should not drop
- [x] Documentation has been updated accordingly (if appropriate)
