### PR TITLE
Browse cards bug/ latest record null bug 

### DIFF
--- a/restaurant/templates/browse.html
+++ b/restaurant/templates/browse.html
@@ -693,20 +693,24 @@ $(document).ready(function(){
                 var a2 = document.createElement("a");
                 a2.className = "text-dark";
                 a2.href = "../restaurant/inspection_records/" + restaurant_list[i].id ;
-                a2.innerHTML = restaurant_list[i].latest_record.is_roadway_compliant;
 
-                if(restaurant_list[i].latest_record.is_roadway_compliant == "Compliant")
-                {
-                    a2.innerHTML += "&nbsp";
-                    var itick = document.createElement("i");
-                    itick.className = "fas fa-check-circle";
-                    itick.style = "color:#596ff8";
-                    p_1.appendChild(a2);
-                    p_1.appendChild(itick);
-                }
-                else
-                {
-                    p_1.appendChild(a2);
+                if (restaurant_list[i].latest_record != null){
+                    a2.innerHTML = restaurant_list[i].latest_record.is_roadway_compliant;
+
+                    if(restaurant_list[i].latest_record.is_roadway_compliant == "Compliant")
+                    {
+                        a2.innerHTML += "&nbsp";
+                        var itick = document.createElement("i");
+                        itick.className = "fas fa-check-circle";
+                        itick.style = "color:#596ff8";
+                        p_1.appendChild(a2);
+                        p_1.appendChild(itick);
+                    }
+                    else
+                    {
+                        p_1.appendChild(a2);
+                    }
+
                 }
 
                 // MOPD Compliance Status 


### PR DESCRIPTION
## Title
Attempting to fix the browse cards bug and the 
## Description
This PR attempts to fix the bug in the Browse UI. In the production instance, "latest_record" yields a null value, meaning some restaurants might not have latest_record. We attempt to fix that error. We will further investigate if this fix has an effect on the browse cards bug, which is that the production instance browse page initially loads 2 restaurant cards instead of 6.


## Types of changes
*Put an `x` in the boxes that apply*
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Enhancement
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/gcivil-nyu-org/spring2021-cs-gy-9223-class/blob/main/CONTRIBUTING.md) guidelines of this project
- [x] My code follows the code style of this project
- [ ] New unit tests have been added to prove my fix is effective or my feature works
- [x] All new and existing unit tests have passed locally
- [ ] Mention new environment variables if any have been added to env file
- [ ] Any new required python modules are added to the requirements.txt
- [x] All checks (continuous integration build) should pass and test coverage should not drop
- [x] Documentation has been updated accordingly (if appropriate)
